### PR TITLE
https redirect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .vscode
+.env

--- a/server/app.js
+++ b/server/app.js
@@ -3,6 +3,14 @@ const app = express();
 const path = require("path");
 module.exports = app;
 
+if (process.env.NODE_ENV === "production") {
+  app.use((req, res, next) => {
+    if (req.header("x-forwarded-proto") !== "https")
+      res.redirect(`https://${req.header("host")}${req.url}`);
+    else next();
+  });
+}
+
 app.use(express.static(path.join(__dirname, "../public")));
 
 app.get("*", function (req, res) {


### PR DESCRIPTION
This should redirect users from http://*reibase.rs to https://reibase.rs

It is the functionality I used to redirect:  [http://www.selected-work.com/](http://www.selected-work.com/) to https

Had to add NODE_ENV environment variables to .env and Heroku, production and development modes.